### PR TITLE
Fixed "WEBSITE_RUN_FROM_PACKAGE" linkage

### DIFF
--- a/DataConnectors/Qualys VM/azuredeploy_QualysVM_API_FunctionApp.json
+++ b/DataConnectors/Qualys VM/azuredeploy_QualysVM_API_FunctionApp.json
@@ -180,7 +180,7 @@
                           "apiPassword": "[parameters('APIPassword')]",
                           "uri": "[parameters('Uri')]",
                           "timeInterval": "[parameters('TimeInterval')]",
-                          "WEBSITE_RUN_FROM_PACKAGE": "https://aka.ms/sentinelqualysvmazurefunctionzip"
+                          "WEBSITE_RUN_FROM_PACKAGE": "https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/Qualys%20VM/AzureFunctionQualysVM.zip?raw=true"
                                    } 
                   }
               ]


### PR DESCRIPTION
The destination from the Microsoft URL shortener is incorrect plus leads to the creators personal fork of the Azure-Sentinel repo. I have added the URL to the zip package within the Azure/Azure-Sentinel repo. This should work fine, or a new MSFT url could be added in stead.